### PR TITLE
feat: add input validation with zod

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,8 @@ import type { Bindings } from './types';
 import { fetchRecipe } from './trmnl-api';
 import { generateBadge } from './badge-generator';
 import { formatNumber } from './utils';
+import { parseBadgeQuery, parseStatsQuery, formatZodError } from './validation';
+import { ZodError } from 'zod';
 
 // 🎉 Fun tracking feature: KV store key for total badges served counter
 const BADGES_SERVED_COUNTER_KEY = 'badges_served_total';
@@ -11,121 +13,134 @@ const app = new Hono<{ Bindings: Bindings }>({ strict: false });
 
 // Badge endpoints for TRMNL recipes
 app.get('/badge/installs', async (c) => {
-  const { recipe, label, pretty } = c.req.query();
+  try {
+    const query = parseBadgeQuery(c.req.query());
+    const recipeData = await fetchRecipe(query.recipe);
 
-  if (!recipe) {
-    return c.text('Missing required parameter: recipe', 400);
-  }
-
-  const recipeData = await fetchRecipe(recipe);
-
-  if (!recipeData) {
-    return c.text('Recipe not found', 404);
-  }
-
-  const isPretty = pretty !== undefined;
-  const badge = generateBadge({
-    label: label || 'Installs',
-    message: formatNumber(recipeData.stats.installs, isPretty),
-  });
-
-  // 🎉 Fun tracking feature: Increment counter
-  // Await the counter update synchronously to ensure it completes
-  if (c.env && c.env.BADGE_COUNTER) {
-    try {
-      const current = await c.env.BADGE_COUNTER.get(BADGES_SERVED_COUNTER_KEY);
-      const count = current ? parseInt(current, 10) : 0;
-
-      // Validate that parseInt produced a valid number
-      if (!Number.isFinite(count)) {
-        console.warn(`Invalid counter value: ${current}, resetting to 0`);
-      }
-
-      const newCount = (Number.isFinite(count) ? count : 0) + 1;
-      await c.env.BADGE_COUNTER.put(BADGES_SERVED_COUNTER_KEY, newCount.toString());
-    } catch (err) {
-      console.error('[installs] Counter error:', err);
+    if (!recipeData) {
+      return c.text('Recipe not found', 404);
     }
-  }
 
-  c.header('Content-Type', 'image/svg+xml');
-  c.header('Cache-Control', 'public, max-age=3600');
-  return c.body(badge);
+    const badge = generateBadge({
+      label: query.label || 'Installs',
+      message: formatNumber(recipeData.stats.installs, query.pretty),
+    });
+
+    // 🎉 Fun tracking feature: Increment counter
+    // Await the counter update synchronously to ensure it completes
+    if (c.env && c.env.BADGE_COUNTER) {
+      try {
+        const current = await c.env.BADGE_COUNTER.get(BADGES_SERVED_COUNTER_KEY);
+        const count = current ? parseInt(current, 10) : 0;
+
+        // Validate that parseInt produced a valid number
+        if (!Number.isFinite(count)) {
+          console.warn(`Invalid counter value: ${current}, resetting to 0`);
+        }
+
+        const newCount = (Number.isFinite(count) ? count : 0) + 1;
+        await c.env.BADGE_COUNTER.put(BADGES_SERVED_COUNTER_KEY, newCount.toString());
+      } catch (err) {
+        console.error('[installs] Counter error:', err);
+      }
+    }
+
+    c.header('Content-Type', 'image/svg+xml');
+    c.header('Cache-Control', 'public, max-age=3600');
+    return c.body(badge);
+  } catch (err: unknown) {
+    // Handle Zod validation errors
+    if (err instanceof ZodError) {
+      const message = formatZodError(err);
+      return c.text(`Invalid parameters: ${message}`, 400);
+    }
+    console.error('[installs] Unexpected error:', err);
+    throw err;
+  }
 });
 
 app.get('/badge/forks', async (c) => {
-  const { recipe, label, pretty } = c.req.query();
+  try {
+    const query = parseBadgeQuery(c.req.query());
+    const recipeData = await fetchRecipe(query.recipe);
 
-  if (!recipe) {
-    return c.text('Missing required parameter: recipe', 400);
-  }
-
-  const recipeData = await fetchRecipe(recipe);
-
-  if (!recipeData) {
-    return c.text('Recipe not found', 404);
-  }
-
-  const isPretty = pretty !== undefined;
-  const badge = generateBadge({
-    label: label || 'Forks',
-    message: formatNumber(recipeData.stats.forks, isPretty),
-  });
-
-  // 🎉 Fun tracking feature: Increment counter
-  // Await the counter update synchronously to ensure it completes
-  if (c.env && c.env.BADGE_COUNTER) {
-    try {
-      const current = await c.env.BADGE_COUNTER.get(BADGES_SERVED_COUNTER_KEY);
-      const count = current ? parseInt(current, 10) : 0;
-
-      // Validate that parseInt produced a valid number
-      if (!Number.isFinite(count)) {
-        console.warn(`Invalid counter value: ${current}, resetting to 0`);
-      }
-
-      const newCount = (Number.isFinite(count) ? count : 0) + 1;
-      await c.env.BADGE_COUNTER.put(BADGES_SERVED_COUNTER_KEY, newCount.toString());
-    } catch (err) {
-      console.error('[forks] Counter error:', err);
+    if (!recipeData) {
+      return c.text('Recipe not found', 404);
     }
-  }
 
-  c.header('Content-Type', 'image/svg+xml');
-  c.header('Cache-Control', 'public, max-age=3600');
-  return c.body(badge);
+    const badge = generateBadge({
+      label: query.label || 'Forks',
+      message: formatNumber(recipeData.stats.forks, query.pretty),
+    });
+
+    // 🎉 Fun tracking feature: Increment counter
+    // Await the counter update synchronously to ensure it completes
+    if (c.env && c.env.BADGE_COUNTER) {
+      try {
+        const current = await c.env.BADGE_COUNTER.get(BADGES_SERVED_COUNTER_KEY);
+        const count = current ? parseInt(current, 10) : 0;
+
+        // Validate that parseInt produced a valid number
+        if (!Number.isFinite(count)) {
+          console.warn(`Invalid counter value: ${current}, resetting to 0`);
+        }
+
+        const newCount = (Number.isFinite(count) ? count : 0) + 1;
+        await c.env.BADGE_COUNTER.put(BADGES_SERVED_COUNTER_KEY, newCount.toString());
+      } catch (err) {
+        console.error('[forks] Counter error:', err);
+      }
+    }
+
+    c.header('Content-Type', 'image/svg+xml');
+    c.header('Cache-Control', 'public, max-age=3600');
+    return c.body(badge);
+  } catch (err: unknown) {
+    // Handle Zod validation errors
+    if (err instanceof ZodError) {
+      const message = formatZodError(err);
+      return c.text(`Invalid parameters: ${message}`, 400);
+    }
+    console.error('[forks] Unexpected error:', err);
+    throw err;
+  }
 });
 
 // API endpoint for TRMNL recipe stats
 app.get('/api/stats', async (c) => {
-  const { recipe } = c.req.query();
+  try {
+    const query = parseStatsQuery(c.req.query());
+    const recipeData = await fetchRecipe(query.recipe);
 
-  if (!recipe) {
-    return c.json({ error: 'Missing required parameter: recipe' }, 400);
+    if (!recipeData) {
+      return c.json({ error: 'Recipe not found' }, 404);
+    }
+
+    const stats = {
+      id: recipeData.id,
+      name: recipeData.name,
+      published_at: recipeData.published_at,
+      stats: {
+        installs: recipeData.stats.installs,
+        forks: recipeData.stats.forks,
+      },
+      author: {
+        github_url: recipeData.author_bio?.github_url || null,
+        learn_more_url: recipeData.author_bio?.learn_more_url || null,
+      },
+    };
+
+    c.header('Cache-Control', 'public, max-age=3600');
+    return c.json(stats);
+  } catch (err: unknown) {
+    // Handle Zod validation errors
+    if (err instanceof ZodError) {
+      const message = formatZodError(err);
+      return c.json({ error: `Invalid parameters: ${message}` }, 400);
+    }
+    console.error('[stats] Unexpected error:', err);
+    throw err;
   }
-
-  const recipeData = await fetchRecipe(recipe);
-
-  if (!recipeData) {
-    return c.json({ error: 'Recipe not found' }, 404);
-  }
-
-  const stats = {
-    id: recipeData.id,
-    name: recipeData.name,
-    published_at: recipeData.published_at,
-    stats: {
-      installs: recipeData.stats.installs,
-      forks: recipeData.stats.forks,
-    },
-    author: {
-      github_url: recipeData.author_bio?.github_url || null,
-      learn_more_url: recipeData.author_bio?.learn_more_url || null,
-    },
-  };
-
-  c.header('Cache-Control', 'public, max-age=3600');
-  return c.json(stats);
 });
 
 ///////////////////////////////////////////////////////////

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -1,0 +1,54 @@
+import { z, ZodError } from 'zod';
+
+/**
+ * Badge endpoint query parameters schema
+ * Validates recipe ID, custom label, and formatting preferences
+ */
+export const badgeQuerySchema = z.object({
+  recipe: z.string().min(1, 'Recipe ID is required').regex(/^\d+$/, 'Recipe ID must be numeric'),
+  label: z.string().optional(),
+  pretty: z.boolean().default(false),
+});
+
+export type BadgeQuery = z.infer<typeof badgeQuerySchema>;
+
+/**
+ * Stats endpoint query parameters schema
+ */
+export const statsQuerySchema = z.object({
+  recipe: z.string().min(1, 'Recipe ID is required').regex(/^\d+$/, 'Recipe ID must be numeric'),
+});
+
+export type StatsQuery = z.infer<typeof statsQuerySchema>;
+
+/**
+ * Parse and validate query parameters with Zod
+ * Returns validated data or throws ZodError
+ */
+export function parseBadgeQuery(params: Record<string, string | string[] | undefined>): BadgeQuery {
+  const parsed = {
+    recipe: Array.isArray(params.recipe) ? params.recipe[0] : params.recipe || '',
+    label: Array.isArray(params.label) ? params.label[0] : params.label,
+    pretty: params.pretty !== undefined, // Presence of parameter treats it as true
+  };
+
+  return badgeQuerySchema.parse(parsed);
+}
+
+/**
+ * Parse and validate stats query parameters
+ */
+export function parseStatsQuery(params: Record<string, string | string[] | undefined>): StatsQuery {
+  const parsed = {
+    recipe: Array.isArray(params.recipe) ? params.recipe[0] : params.recipe || '',
+  };
+
+  return statsQuerySchema.parse(parsed);
+}
+
+/**
+ * Format ZodError for user-friendly error messages
+ */
+export function formatZodError(err: ZodError): string {
+  return err.issues.map((issue) => `${issue.path.join('.')}: ${issue.message}`).join(', ');
+}

--- a/test/endpoints.test.ts
+++ b/test/endpoints.test.ts
@@ -61,7 +61,9 @@ describe('TRMNL Badges API', () => {
     it('should return 400 when recipe parameter is missing', async () => {
       const response = await app.request('/badge/installs');
       expect(response.status).toBe(400);
-      expect(await response.text()).toBe('Missing required parameter: recipe');
+      const text = await response.text();
+      expect(text).toContain('Invalid parameters');
+      expect(text).toContain('Recipe ID is required');
     });
 
     it('should return 404 when recipe is not found', async () => {
@@ -123,7 +125,9 @@ describe('TRMNL Badges API', () => {
     it('should return 400 when recipe parameter is missing', async () => {
       const response = await app.request('/badge/forks');
       expect(response.status).toBe(400);
-      expect(await response.text()).toBe('Missing required parameter: recipe');
+      const text = await response.text();
+      expect(text).toContain('Invalid parameters');
+      expect(text).toContain('Recipe ID is required');
     });
 
     it('should return 404 when recipe is not found', async () => {
@@ -175,8 +179,9 @@ describe('TRMNL Badges API', () => {
       const response = await app.request('/api/stats');
       expect(response.status).toBe(400);
 
-      const json = await response.json();
-      expect(json).toHaveProperty('error', 'Missing required parameter: recipe');
+      const json = (await response.json()) as any;
+      expect(json.error).toContain('Invalid parameters');
+      expect(json.error).toContain('Recipe ID is required');
     });
 
     it('should return 404 when recipe is not found', async () => {


### PR DESCRIPTION
## Overview
This PR adds comprehensive input validation using Zod to all query parameters across the API endpoints, improving robustness and providing better error messages to API consumers.

## Changes

### New File: `src/validation.ts`
- **Zod schemas** for query parameters with validation rules
  - `badgeQuerySchema`: Validates `recipe` (required, numeric), `label` (optional string), `pretty` (optional boolean)
  - `statsQuerySchema`: Validates `recipe` (required, numeric)
- **Parser functions** (`parseBadgeQuery`, `parseStatsQuery`) that safely convert and validate raw query parameters
- **`formatZodError()`** utility to format validation errors into user-friendly messages

### Updated Endpoints
All endpoints now use Zod validation with proper error handling:
- `/badge/installs` - Validates badge query parameters
- `/badge/forks` - Validates badge query parameters  
- `/api/stats` - Validates stats query parameters

**Error Response Behavior:**
- Valid parameters → Process normally (HTTP 200)
- Invalid parameters → HTTP 400 with detailed error description
  - Example: `"Invalid parameters: recipe: Recipe ID is required, recipe: Recipe ID must be numeric"`
- Unexpected errors → HTTP 500

### Benefits
✨ **Type-safe** parameter validation using Zod schemas  
✨ **Better error messages** that help API consumers debug issues  
✨ **Reusable** validation schemas across endpoints  
✨ **Consistent** error handling pattern across all endpoints  
✨ **Future-proof** for adding more validation rules  
✨ **Uses existing dependency** - Zod was already in package.json

## Testing
- All 49 existing tests pass
- Updated 3 tests to expect new validation error format
- Test coverage maintained at current levels

## Migration Notes
API consumers may see different error messages for invalid parameters. The HTTP status codes remain the same (400 for validation errors).

Example before/after:
```
Before: Missing required parameter: recipe
After:  Invalid parameters: recipe: Recipe ID is required, recipe: Recipe ID must be numeric
```

This is more descriptive and helps developers understand what went wrong.