### PR TITLE
feat: add connections badge endpoint combining installs and forks

### DIFF
--- a/index.html
+++ b/index.html
@@ -465,6 +465,10 @@
               <input type="radio" id="typeForks" name="badgeType" value="forks">
               <label for="typeForks" class="radio-label">Forks</label>
             </div>
+            <div class="radio-option">
+              <input type="radio" id="typeConnections" name="badgeType" value="connections">
+              <label for="typeConnections" class="radio-label">Connections</label>
+            </div>
           </div>
         </div>
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -142,6 +142,73 @@ app.get('/badge/forks', async (c) => {
   }
 });
 
+app.get('/badge/connections', async (c) => {
+  try {
+    const { recipe, label, pretty } = c.req.query();
+
+    if (!recipe) {
+      const errorBadge = generateErrorBadge(label || 'Connections', 'Missing recipe ID');
+      c.header('Content-Type', 'image/svg+xml');
+      c.header('Cache-Control', 'public, max-age=60');
+      return c.body(errorBadge);
+    }
+
+    let recipeData;
+    try {
+      recipeData = await fetchRecipe(recipe);
+    } catch (err) {
+      console.error('[connections] Network error fetching recipe:', err);
+      const errorBadge = generateErrorBadge(label || 'Connections', 'Network Error');
+      c.header('Content-Type', 'image/svg+xml');
+      c.header('Cache-Control', 'public, max-age=60');
+      return c.body(errorBadge);
+    }
+
+    if (!recipeData) {
+      const errorBadge = generateErrorBadge(label || 'Connections', 'Recipe Not Found');
+      c.header('Content-Type', 'image/svg+xml');
+      c.header('Cache-Control', 'public, max-age=60');
+      return c.body(errorBadge);
+    }
+
+    const isPretty = pretty !== undefined;
+    const totalConnections = recipeData.stats.installs + recipeData.stats.forks;
+    const badge = generateBadge({
+      label: label || 'Connections',
+      message: formatNumber(totalConnections, isPretty),
+    });
+
+    // 🎉 Fun tracking feature: Increment counter
+    // Await the counter update synchronously to ensure it completes
+    if (c.env && c.env.BADGE_COUNTER) {
+      try {
+        const current = await c.env.BADGE_COUNTER.get(BADGES_SERVED_COUNTER_KEY);
+        const count = current ? parseInt(current, 10) : 0;
+
+        // Validate that parseInt produced a valid number
+        if (!Number.isFinite(count)) {
+          console.warn(`Invalid counter value: ${current}, resetting to 0`);
+        }
+
+        const newCount = (Number.isFinite(count) ? count : 0) + 1;
+        await c.env.BADGE_COUNTER.put(BADGES_SERVED_COUNTER_KEY, newCount.toString());
+      } catch (err) {
+        console.error('[connections] Counter error:', err);
+      }
+    }
+
+    c.header('Content-Type', 'image/svg+xml');
+    c.header('Cache-Control', 'public, max-age=3600');
+    return c.body(badge);
+  } catch (err) {
+    console.error('[connections] Unexpected error:', err);
+    const errorBadge = generateErrorBadge('Connections', 'Service Error');
+    c.header('Content-Type', 'image/svg+xml');
+    c.header('Cache-Control', 'public, max-age=60');
+    return c.body(errorBadge);
+  }
+});
+
 // API endpoint for TRMNL recipe stats
 app.get('/api/stats', async (c) => {
   const { recipe } = c.req.query();

--- a/test/endpoints.test.ts
+++ b/test/endpoints.test.ts
@@ -256,6 +256,118 @@ describe('TRMNL Badges API', () => {
     });
   });
 
+  describe('GET /badge/connections', () => {
+    it('should return error badge when recipe parameter is missing', async () => {
+      const response = await app.request('/badge/connections');
+      expect(response.status).toBe(200);
+      expect(response.headers.get('Content-Type')).toBe('image/svg+xml');
+      const svg = await response.text();
+      expect(svg).toContain('Missing recipe ID');
+    });
+
+    it('should return error badge when recipe is not found', async () => {
+      vi.mocked(fetchRecipe).mockResolvedValueOnce(null);
+
+      const response = await app.request('/badge/connections?recipe=999999');
+      expect(response.status).toBe(200);
+      expect(response.headers.get('Content-Type')).toBe('image/svg+xml');
+      const svg = await response.text();
+      expect(svg).toContain('Recipe Not Found');
+    });
+
+    it('should return error badge when network error occurs', async () => {
+      vi.mocked(fetchRecipe).mockRejectedValueOnce(new Error('Network error'));
+      const consoleMock = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      const response = await app.request('/badge/connections?recipe=240176');
+      expect(response.status).toBe(200);
+      expect(response.headers.get('Content-Type')).toBe('image/svg+xml');
+      expect(response.headers.get('Cache-Control')).toBe('public, max-age=60');
+      const svg = await response.text();
+      expect(svg).toContain('Network Error');
+      expect(consoleMock).toHaveBeenCalledWith(
+        '[connections] Network error fetching recipe:',
+        expect.any(Error)
+      );
+      consoleMock.mockRestore();
+    });
+
+    it('should generate a connections badge combining installs and forks', async () => {
+      vi.mocked(fetchRecipe).mockResolvedValueOnce(mockRecipe);
+
+      const response = await app.request('/badge/connections?recipe=240176');
+      expect(response.status).toBe(200);
+      expect(response.headers.get('Content-Type')).toBe('image/svg+xml');
+      expect(response.headers.get('Cache-Control')).toBe('public, max-age=3600');
+
+      const svg = await response.text();
+      expect(svg).toContain('Connections');
+      // mockRecipe has installs: 7 and forks: 5, total should be 12
+      expect(svg).toContain('12');
+    });
+
+    it('should support custom label', async () => {
+      vi.mocked(fetchRecipe).mockResolvedValueOnce(mockRecipe);
+
+      const response = await app.request('/badge/connections?recipe=240176&label=Total Users');
+      expect(response.status).toBe(200);
+
+      const svg = await response.text();
+      expect(svg).toContain('Total Users');
+      expect(svg).toContain('12');
+    });
+
+    it('should support pretty formatting for large numbers', async () => {
+      vi.mocked(fetchRecipe).mockResolvedValueOnce(mockRecipeHighEngagement);
+
+      const response = await app.request('/badge/connections?recipe=999999&pretty');
+      expect(response.status).toBe(200);
+
+      const svg = await response.text();
+      expect(svg).toContain('Connections');
+      // mockRecipeHighEngagement has installs: 1500 and forks: 250, total should be 1750 = 1.75K
+      expect(svg).toContain('1.75K');
+    });
+
+    it('should return service error badge for unexpected errors', async () => {
+      vi.mocked(fetchRecipe).mockResolvedValueOnce(mockRecipe);
+      const consoleMock = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      // Mock KV that throws unexpected error during counter increment
+      const failingKV = {
+        get: vi.fn().mockRejectedValue(new Error('KV error')),
+        put: vi.fn().mockRejectedValue(new Error('KV error')),
+      };
+      const bindings = { NODE_ENV: 'production', BADGE_COUNTER: failingKV };
+
+      const response = await app.request('/badge/connections?recipe=240176', {}, bindings);
+
+      // Should still return 200 with badge despite KV error
+      expect(response.status).toBe(200);
+      expect(response.headers.get('Content-Type')).toBe('image/svg+xml');
+      const svg = await response.text();
+      expect(svg).toContain('Connections');
+      expect(svg).toContain('12');
+      consoleMock.mockRestore();
+    });
+
+    it('should increment counter when /badge/connections is called', async () => {
+      vi.mocked(fetchRecipe).mockResolvedValueOnce(mockRecipe);
+
+      const mockKV = {
+        get: vi.fn().mockResolvedValue(null),
+        put: vi.fn().mockResolvedValue(undefined),
+      };
+      const bindings = { NODE_ENV: 'production', BADGE_COUNTER: mockKV };
+
+      // Make a badge request
+      await app.request('/badge/connections?recipe=240176', {}, bindings);
+
+      // Check that counter was incremented
+      expect(mockKV.put).toHaveBeenCalledWith('badges_served_total', '1');
+    });
+  });
+
   describe('GET /api/stats', () => {
     it('should return 400 when recipe parameter is missing', async () => {
       const response = await app.request('/api/stats');


### PR DESCRIPTION
## Overview
Add a new connections badge type that combines installs and forks metrics into a single badge value.

## Problem
Users may want to see total engagement (installs + forks) in a single badge, which currently requires embedding two separate badges.

## Solution
New `/badge/connections` endpoint that:
- Sums `installs` and `forks` statistics
- Provides the same error handling, formatting, and customization as other badges
- Always returns HTTP 200 with badges (never HTTP errors)

## Changes

### New API Endpoint
```
GET /badge/connections?recipe=RECIPE_ID[&label=Custom][&pretty]
```

**Example responses:**
- `https://trmnl-badges.gohk.xyz/badge/connections?recipe=28496`
  - Shows total: 555 + 199 = 754
- `https://trmnl-badges.gohk.xyz/badge/connections?recipe=28496&label=Total%20Users&pretty`
  - Shows: "Total Users | 754" with pretty formatting if needed

### Features
- ✅ Combines installs + forks values
- ✅ Supports custom labels: `?label=My Label`
- ✅ Supports pretty number formatting: `?pretty`
- ✅ Full error handling with red error badges
- ✅ Increments badge counter for tracking
- ✅ 3600s cache for success, 60s for errors

### Updated Components
- `src/index.ts` - Added `/badge/connections` endpoint (70 lines)
- `index.html` - Added "Connections" radio button option
- `test/endpoints.test.ts` - Added 8 comprehensive tests

### Test Coverage
All new functionality tested:
- Missing recipe error
- Recipe not found error
- Network error handling
- Basic functionality (installs + forks)
- Custom labels
- Pretty number formatting
- Unexpected error handling
- Counter increment

**Results:** ✅ 68 tests passing (60 existing + 8 new)

## Example Badge
Badge for recipe 28496 showing connections:
```
https://trmnl-badges.gohk.xyz/badge/connections?recipe=28496
```
Returns: SVG badge showing "Connections | 754"

## Backward Compatibility
✅ No breaking changes
- Existing `/badge/installs` and `/badge/forks` unchanged
- All existing tests passing
- Builder UI enhanced with new option