### PR TITLE
fix: check content-type before response.ok to handle redirects

### DIFF
--- a/src/trmnl-api.ts
+++ b/src/trmnl-api.ts
@@ -16,18 +16,18 @@ export async function fetchRecipe(recipeId: string): Promise<TRMNLRecipe | null>
   try {
     const response = await fetch(url, { headers });
 
+    // Check if response is JSON (a 302 redirect to recipes page returns HTML)
+    const contentType = response.headers.get('content-type');
+    if (!contentType?.includes('application/json')) {
+      // Recipe not found (API redirects to recipe list page with HTML, or other non-JSON response)
+      return null;
+    }
+
     if (!response.ok) {
       if (response.status === 404) {
         return null;
       }
       throw new Error(`TRMNL API error: ${response.status} ${response.statusText}`);
-    }
-
-    // Check if response is JSON (a 302 redirect to recipes page returns HTML)
-    const contentType = response.headers.get('content-type');
-    if (!contentType?.includes('application/json')) {
-      // Recipe not found (API redirects to recipe list page with HTML)
-      return null;
     }
 
     const result = (await response.json()) as { data: TRMNLRecipe };


### PR DESCRIPTION
## Problem
When requesting a non-existent recipe, the TRMNL API returns a 302 redirect with HTML content. The code was checking `response.ok` before checking the content-type, causing the error to be caught by the outer exception handler and displayed as "Service Error" instead of "Recipe Not Found".

## Solution
Reorder the checks in `fetchRecipe()`:
1. **First**: Check if response is JSON (by content-type header)
2. **Then**: Check the HTTP status code

This allows us to properly detect 302 redirects with HTML content before evaluating the status code, returning `null` for non-existent recipes.

## Result
Non-existent recipes now properly display "Recipe Not Found" error badge instead of "Service Error".

## Testing
- ✅ Invalid recipe ID shows "Recipe Not Found" badge
- ✅ Valid recipes continue to work normally
- ✅ Network errors still show "Network Error" badge
- ✅ Missing recipe ID shows "Missing recipe ID" badge