### PR TITLE
fix: add defensive checks for recipe stats to prevent undefined errors

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -39,6 +39,13 @@ app.get('/badge/installs', async (c) => {
       return c.body(errorBadge);
     }
 
+    if (!recipeData.stats?.installs) {
+      const errorBadge = generateErrorBadge(label || 'Installs', 'Recipe Not Found');
+      c.header('Content-Type', 'image/svg+xml');
+      c.header('Cache-Control', 'public, max-age=60');
+      return c.body(errorBadge);
+    }
+
     const isPretty = pretty !== undefined;
     const badge = generateBadge({
       label: label || 'Installs',
@@ -105,6 +112,13 @@ app.get('/badge/forks', async (c) => {
       return c.body(errorBadge);
     }
 
+    if (!recipeData.stats?.forks) {
+      const errorBadge = generateErrorBadge(label || 'Forks', 'Recipe Not Found');
+      c.header('Content-Type', 'image/svg+xml');
+      c.header('Cache-Control', 'public, max-age=60');
+      return c.body(errorBadge);
+    }
+
     const isPretty = pretty !== undefined;
     const badge = generateBadge({
       label: label || 'Forks',
@@ -165,6 +179,13 @@ app.get('/badge/connections', async (c) => {
     }
 
     if (!recipeData) {
+      const errorBadge = generateErrorBadge(label || 'Connections', 'Recipe Not Found');
+      c.header('Content-Type', 'image/svg+xml');
+      c.header('Cache-Control', 'public, max-age=60');
+      return c.body(errorBadge);
+    }
+
+    if (!recipeData.stats?.installs || !recipeData.stats?.forks) {
       const errorBadge = generateErrorBadge(label || 'Connections', 'Recipe Not Found');
       c.header('Content-Type', 'image/svg+xml');
       c.header('Cache-Control', 'public, max-age=60');


### PR DESCRIPTION
## Problem
Cloudflare logs showed errors when testing with non-existent recipe IDs:
```
TypeError: Cannot read properties of undefined (reading 'installs')
TypeError: Cannot read properties of undefined (reading 'forks')
```

This can occur if the TRMNL API returns a recipe object with missing or incomplete `stats` data.

## Solution
Add defensive checks using optional chaining (`?.`) before accessing recipe stats:
- Check `recipeData.stats?.installs` before using it
- Check `recipeData.stats?.forks` before using it
- Return "Recipe Not Found" error badge if stats are invalid or missing

This prevents undefined reference errors and provides graceful error handling.

## Changes
- Modified all three badge endpoints (`/badge/installs`, `/badge/forks`, `/badge/connections`)
- Added optional chaining validation checks
- Consistent error handling across all endpoints

## Testing
- ✅ All 75 tests pass
- ✅ TypeScript compilation passes
- ✅ Defensive checks catch missing/invalid stats gracefully