### PR TITLE
fix: allow 0 values in recipe stats checks

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -39,7 +39,7 @@ app.get('/badge/installs', async (c) => {
       return c.body(errorBadge);
     }
 
-    if (!recipeData.stats?.installs) {
+    if (recipeData.stats?.installs === undefined) {
       const errorBadge = generateErrorBadge(label || 'Installs', 'Recipe Not Found');
       c.header('Content-Type', 'image/svg+xml');
       c.header('Cache-Control', 'public, max-age=60');
@@ -112,7 +112,7 @@ app.get('/badge/forks', async (c) => {
       return c.body(errorBadge);
     }
 
-    if (!recipeData.stats?.forks) {
+    if (recipeData.stats?.forks === undefined) {
       const errorBadge = generateErrorBadge(label || 'Forks', 'Recipe Not Found');
       c.header('Content-Type', 'image/svg+xml');
       c.header('Cache-Control', 'public, max-age=60');
@@ -185,7 +185,7 @@ app.get('/badge/connections', async (c) => {
       return c.body(errorBadge);
     }
 
-    if (!recipeData.stats?.installs || !recipeData.stats?.forks) {
+    if (recipeData.stats?.installs === undefined || recipeData.stats?.forks === undefined) {
       const errorBadge = generateErrorBadge(label || 'Connections', 'Recipe Not Found');
       c.header('Content-Type', 'image/svg+xml');
       c.header('Cache-Control', 'public, max-age=60');

--- a/test/endpoints.test.ts
+++ b/test/endpoints.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import app from '../src/index';
-import { mockRecipe, mockRecipeHighEngagement } from './fixtures';
+import { mockRecipe, mockRecipeHighEngagement, mockRecipeZeroStats, mockRecipeZeroForks } from './fixtures';
 
 // Mock the fetchRecipe function
 vi.mock('../src/trmnl-api', () => ({
@@ -160,6 +160,18 @@ describe('TRMNL Badges API', () => {
       expect(svg).toContain('7');
       consoleMock.mockRestore();
     });
+
+    it('should handle 0 installs correctly', async () => {
+      vi.mocked(fetchRecipe).mockResolvedValueOnce(mockRecipeZeroStats);
+
+      const response = await app.request('/badge/installs?recipe=231754');
+      expect(response.status).toBe(200);
+
+      const svg = await response.text();
+      expect(svg).toContain('Installs');
+      expect(svg).toContain('0');
+      expect(svg).not.toContain('Recipe Not Found');
+    });
   });
 
   describe('GET /badge/forks', () => {
@@ -253,6 +265,18 @@ describe('TRMNL Badges API', () => {
       expect(svg).toContain('Forks');
       expect(svg).toContain('5');
       consoleMock.mockRestore();
+    });
+
+    it('should handle 0 forks correctly', async () => {
+      vi.mocked(fetchRecipe).mockResolvedValueOnce(mockRecipeZeroForks);
+
+      const response = await app.request('/badge/forks?recipe=231754');
+      expect(response.status).toBe(200);
+
+      const svg = await response.text();
+      expect(svg).toContain('Forks');
+      expect(svg).toContain('0');
+      expect(svg).not.toContain('Recipe Not Found');
     });
   });
 
@@ -349,6 +373,18 @@ describe('TRMNL Badges API', () => {
       expect(svg).toContain('Connections');
       expect(svg).toContain('12');
       consoleMock.mockRestore();
+    });
+
+    it('should handle 0 connections (0 installs and 0 forks)', async () => {
+      vi.mocked(fetchRecipe).mockResolvedValueOnce(mockRecipeZeroStats);
+
+      const response = await app.request('/badge/connections?recipe=231754');
+      expect(response.status).toBe(200);
+
+      const svg = await response.text();
+      expect(svg).toContain('Connections');
+      expect(svg).toContain('0');
+      expect(svg).not.toContain('Recipe Not Found');
     });
 
     it('should increment counter when /badge/connections is called', async () => {

--- a/test/fixtures.ts
+++ b/test/fixtures.ts
@@ -29,3 +29,23 @@ export const mockRecipeHighEngagement: TRMNLRecipe = {
     forks: 250,
   },
 };
+
+export const mockRecipeZeroStats: TRMNLRecipe = {
+  ...mockRecipe,
+  id: 231754,
+  name: 'New Recipe',
+  stats: {
+    installs: 0,
+    forks: 0,
+  },
+};
+
+export const mockRecipeZeroForks: TRMNLRecipe = {
+  ...mockRecipe,
+  id: 231754,
+  name: 'Rarely Forked Recipe',
+  stats: {
+    installs: 42,
+    forks: 0,
+  },
+};


### PR DESCRIPTION
## Problem
Recipes with 0 forks or 0 installs were incorrectly showing "Recipe Not Found" error badge instead of displaying the correct value.

Example: Recipe #231754 has `forks: 0` but was failing validation.

## Root Cause
The defensive checks used falsy evaluation (`!value`) which treats `0` as false:
```typescript
if (!recipeData.stats?.forks) {  // ❌ This treats 0 as invalid
```

## Solution
Changed defensive checks to explicitly check for `undefined`:
```typescript
if (recipeData.stats?.forks === undefined) {  // ✅ Allows 0 as valid
```

## Changes
- Modified `/badge/installs`, `/badge/forks`, `/badge/connections` endpoints
- Changed falsy checks to explicit undefined checks
- Added test fixtures for zero stats scenarios
- Added 3 new test cases for recipes with 0 stats

## Testing
- ✅ All 78 tests passing (3 new tests added)
- ✅ Added `mockRecipeZeroStats` fixture (0 installs, 0 forks)
- ✅ Added `mockRecipeZeroForks` fixture (42 installs, 0 forks)
- ✅ Test cases for installs=0, forks=0, connections=0