### PR TITLE
refactor: extract success badge response helper

### DIFF
--- a/src/badge-helpers.ts
+++ b/src/badge-helpers.ts
@@ -18,6 +18,16 @@ export function returnErrorBadge(
 }
 
 /**
+ * Return success badge response with proper headers
+ * Used for successful badge generation responses
+ */
+export function returnSuccessBadge(context: Context<{ Bindings: Bindings }>, badge: string) {
+  context.header('Content-Type', 'image/svg+xml');
+  context.header('Cache-Control', 'public, max-age=3600');
+  return context.body(badge);
+}
+
+/**
  * Validate recipe data and its stats
  * Returns true if valid, false if should show error
  * Serves as a type guard to ensure recipeData is not null/undefined

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@ import type { Bindings } from './types';
 import { fetchRecipe } from './trmnl-api';
 import { generateBadge } from './badge-generator';
 import { formatNumber } from './utils';
-import { returnErrorBadge, isRecipeValid } from './badge-helpers';
+import { returnErrorBadge, isRecipeValid, returnSuccessBadge } from './badge-helpers';
 
 // 🎉 Fun tracking feature: KV store key for total badges served counter
 const BADGES_SERVED_COUNTER_KEY = 'badges_served_total';
@@ -56,9 +56,7 @@ app.get('/badge/installs', async (context) => {
       }
     }
 
-    context.header('Content-Type', 'image/svg+xml');
-    context.header('Cache-Control', 'public, max-age=3600');
-    return context.body(badge);
+    return returnSuccessBadge(context, badge);
   } catch (err) {
     console.error('[installs] Unexpected error:', err);
     return returnErrorBadge(context, 'Installs', 'Service Error');
@@ -110,9 +108,7 @@ app.get('/badge/forks', async (context) => {
       }
     }
 
-    context.header('Content-Type', 'image/svg+xml');
-    context.header('Cache-Control', 'public, max-age=3600');
-    return context.body(badge);
+    return returnSuccessBadge(context, badge);
   } catch (err) {
     console.error('[forks] Unexpected error:', err);
     return returnErrorBadge(context, 'Forks', 'Service Error');
@@ -169,9 +165,7 @@ app.get('/badge/connections', async (context) => {
       }
     }
 
-    context.header('Content-Type', 'image/svg+xml');
-    context.header('Cache-Control', 'public, max-age=3600');
-    return context.body(badge);
+    return returnSuccessBadge(context, badge);
   } catch (err) {
     console.error('[connections] Unexpected error:', err);
     return returnErrorBadge(context, 'Connections', 'Service Error');
@@ -262,9 +256,7 @@ app.get('/badge/counter', async (context) => {
     message: formatNumber(validCount, true),
   });
 
-  context.header('Content-Type', 'image/svg+xml');
-  context.header('Cache-Control', 'public, max-age=3600'); // Cache for 1 hour
-  return context.body(badge);
+  return returnSuccessBadge(context, badge);
 });
 
 export default app;


### PR DESCRIPTION
## Description

This PR extracts the success badge response pattern into a dedicated helper function to reduce code duplication.

## Changes

### Extract Success Badge Response Helper
- Add `returnSuccessBadge()` helper function to `src/badge-helpers.ts`
- Centralizes Content-Type and Cache-Control header setting
- Replace 4 duplicate response patterns with single helper call:
  - `/badge/installs` endpoint
  - `/badge/forks` endpoint
  - `/badge/connections` endpoint
  - `/badge/counter` endpoint

## Benefits

- Reduces code duplication by ~12 lines
- Improves maintainability of badge response format
- Single source of truth for response headers
- Easier to modify response format in the future

## Quality Metrics

- ✅ All 78 tests passing
- ✅ TypeScript compilation clean (no errors)
- ✅ Code properly formatted with Prettier
- ✅ No behavioral changes, purely refactoring

## Files Changed

- `src/badge-helpers.ts`: Added `returnSuccessBadge()` helper
- `src/index.ts`: Updated all success responses to use helper