### PR TITLE
chore: update version to 1.2.0 and add version to health endpoint

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,11 +37,13 @@ trmnl-badges/
 ## API Endpoints
 
 ### Badge Endpoints
+
 - `GET /badge/installs?recipe=<recipe_id>` - Recipe install count badge
 - `GET /badge/forks?recipe=<recipe_id>` - Recipe fork count badge
 - `GET /badge/connections?recipe=<recipe_id>` - Recipe connections count badge (sum of installs and forks)
 
 ### Utility Endpoints
+
 - `GET /health` - Health check endpoint
 - `GET /health-badge` - Health badge endpoint for shields.io monitoring
 - `GET /api/stats?recipe=<recipe_id>` - JSON stats for TRMNL recipes
@@ -49,6 +51,7 @@ trmnl-badges/
 - `GET /` - Redirects to GitHub repository
 
 ### Query Parameters
+
 - `recipe` (required) - TRMNL recipe ID
 - `label` (optional) - Custom label text for the badge
 - `pretty` (optional) - Format numbers in compact notation (e.g., 1.2K)
@@ -62,6 +65,7 @@ GET /health-badge
 ```
 
 Response format:
+
 ```json
 {
   "schemaVersion": 1,
@@ -72,16 +76,19 @@ Response format:
 ```
 
 Usage with shields.io:
+
 ```markdown
 [![Health](https://img.shields.io/endpoint?url=https://trmnl-badges.gohk.xyz/health-badge)](https://trmnl-badges.gohk.xyz/health)
 ```
 
 Related endpoints:
+
 - `GET /health` - JSON health status check (returns status, timestamp, projectUrl)
 
 ### API Examples
 
 #### Badge Endpoints
+
 ```
 # Installs badge
 https://trmnl-badges.gohk.xyz/badge/installs?recipe=28496
@@ -103,11 +110,13 @@ https://trmnl-badges.gohk.xyz/badge/installs?recipe=28496&label=Downloads
 ```
 
 #### Stats API
+
 ```
 https://trmnl-badges.gohk.xyz/api/stats?recipe=28496
 ```
 
 Returns:
+
 ```json
 {
   "id": 28496,
@@ -165,6 +174,7 @@ https://trmnl.com/recipes/{recipe_id}.json
 ```
 
 Response includes:
+
 - Recipe metadata (id, name, published_at)
 - Statistics (installs, forks)
 - Author information
@@ -172,8 +182,9 @@ Response includes:
 ## Badge Generation
 
 Badges are generated using the `badgen` library with:
+
 - **TRMNL Logo**: Official TRMNL glyph SVG
-- **Brand Colors**: 
+- **Brand Colors**:
   - Primary: `#F8654B` (orange)
   - Dark: `#3D3D3E` (dark gray)
   - Light: `#E7E7E7` (light gray)
@@ -189,10 +200,12 @@ Badges are generated using the `badgen` library with:
 ## Performance Optimizations
 
 ### Client-Side
+
 - **Input debouncing**: Custom label input is debounced (300ms) to prevent excessive requests while typing
 - This significantly reduces server load when users are actively composing labels
 
 ### Server-Side
+
 - **HTTP Caching**: All badge endpoints return appropriate cache headers:
   - Error responses: `Cache-Control: public, max-age=60` (1 minute)
   - Success responses: `Cache-Control: public, max-age=3600` (1 hour)

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Add badges to your TRMNL recipe documentation using Markdown or HTML.
 ### Finding Your Recipe ID
 
 Your recipe ID can be found in the URL of your [recipe page](https://trmnl.com/recipes) on TRMNL:
+
 ```
 https://trmnl.com/recipes/28496
                           ^^^^^
@@ -41,15 +42,14 @@ https://trmnl.com/recipes/28496
 
 ### Badge Examples
 
-| Badge Type | Code | Preview |
-|------------|------|---------|
-| **Installs** | `![Installs](https://trmnl-badges.gohk.xyz/badge/installs?recipe=28496)` | ![Installs](https://trmnl-badges.gohk.xyz/badge/installs?recipe=28496) |
-| **Forks** | `![Forks](https://trmnl-badges.gohk.xyz/badge/forks?recipe=28496)` | ![Forks](https://trmnl-badges.gohk.xyz/badge/forks?recipe=28496) |
-| **Connections** | `![Connections](https://trmnl-badges.gohk.xyz/badge/connections?recipe=28496)` | ![Connections](https://trmnl-badges.gohk.xyz/badge/connections?recipe=28496) |
-| **Pretty Format** | `![Installs](https://trmnl-badges.gohk.xyz/badge/installs?recipe=9917&pretty)` | ![Installs](https://trmnl-badges.gohk.xyz/badge/installs?recipe=9917&pretty) |
-| **Custom Label** | `![Downloads](https://trmnl-badges.gohk.xyz/badge/installs?recipe=28496&label=Download%20Count)` | ![Downloads](https://trmnl-badges.gohk.xyz/badge/installs?recipe=28496&label=Download%20Count) |
-| **Linked Badge** | `[![Installs](https://trmnl-badges.gohk.xyz/badge/installs?recipe=28496)](https://trmnl.com/recipes/28496)` | [![Installs](https://trmnl-badges.gohk.xyz/badge/installs?recipe=28496)](https://trmnl.com/recipes/28496) |
-
+| Badge Type        | Code                                                                                                        | Preview                                                                                                   |
+| ----------------- | ----------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------- |
+| **Installs**      | `![Installs](https://trmnl-badges.gohk.xyz/badge/installs?recipe=28496)`                                    | ![Installs](https://trmnl-badges.gohk.xyz/badge/installs?recipe=28496)                                    |
+| **Forks**         | `![Forks](https://trmnl-badges.gohk.xyz/badge/forks?recipe=28496)`                                          | ![Forks](https://trmnl-badges.gohk.xyz/badge/forks?recipe=28496)                                          |
+| **Connections**   | `![Connections](https://trmnl-badges.gohk.xyz/badge/connections?recipe=28496)`                              | ![Connections](https://trmnl-badges.gohk.xyz/badge/connections?recipe=28496)                              |
+| **Pretty Format** | `![Installs](https://trmnl-badges.gohk.xyz/badge/installs?recipe=9917&pretty)`                              | ![Installs](https://trmnl-badges.gohk.xyz/badge/installs?recipe=9917&pretty)                              |
+| **Custom Label**  | `![Downloads](https://trmnl-badges.gohk.xyz/badge/installs?recipe=28496&label=Download%20Count)`            | ![Downloads](https://trmnl-badges.gohk.xyz/badge/installs?recipe=28496&label=Download%20Count)            |
+| **Linked Badge**  | `[![Installs](https://trmnl-badges.gohk.xyz/badge/installs?recipe=28496)](https://trmnl.com/recipes/28496)` | [![Installs](https://trmnl-badges.gohk.xyz/badge/installs?recipe=28496)](https://trmnl.com/recipes/28496) |
 
 ## Badge URL Query Parameters
 
@@ -61,35 +61,41 @@ https://trmnl.com/recipes/28496
 > Use the **[TRMNL Badge Builder](https://hossain-khan.github.io/trmnl-badges/)** to generate badge markup.
 
 ### HTML Usage
+
 ```html
-<img src="https://trmnl-badges.gohk.xyz/badge/installs?recipe=28496" alt="Installs">
-<img src="https://trmnl-badges.gohk.xyz/badge/forks?recipe=28496" alt="Forks">
-<img src="https://trmnl-badges.gohk.xyz/badge/connections?recipe=28496" alt="Connections">
+<img src="https://trmnl-badges.gohk.xyz/badge/installs?recipe=28496" alt="Installs" />
+<img src="https://trmnl-badges.gohk.xyz/badge/forks?recipe=28496" alt="Forks" />
+<img src="https://trmnl-badges.gohk.xyz/badge/connections?recipe=28496" alt="Connections" />
 ```
 
 ## Examples
 
 ### Installs Badge
+
 ```
 https://trmnl-badges.gohk.xyz/badge/installs?recipe=28496
 ```
 
 ### Forks Badge
+
 ```
 https://trmnl-badges.gohk.xyz/badge/forks?recipe=28496
 ```
 
 ### Connections Badge
+
 ```
 https://trmnl-badges.gohk.xyz/badge/connections?recipe=28496
 ```
 
 ### Badge with Pretty Formatting (e.g., 2.7K)
+
 ```
 https://trmnl-badges.gohk.xyz/badge/installs?recipe=28496&pretty
 ```
 
 ### Custom Label
+
 ```
 https://trmnl-badges.gohk.xyz/badge/installs?recipe=28496&label=Download%20Count
 ```

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "trmnl-badges",
   "private": true,
-  "version": "1.0.0",
+  "version": "1.2.0",
   "description": "TRMNL Badges - Cloudflare Workers app for generating TRMNL recipe badges",
   "type": "module",
   "main": "index.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,9 @@ import { generateBadge } from './badge-generator';
 import { formatNumber } from './utils';
 import { returnErrorBadge, isRecipeValid, returnSuccessBadge } from './badge-helpers';
 
+// App version - https://github.com/hossain-khan/trmnl-badges/releases
+const APP_VERSION = '1.2.0';
+
 // 🎉 Fun tracking feature: KV store key for total badges served counter
 const BADGES_SERVED_COUNTER_KEY = 'badges_served_total';
 
@@ -211,6 +214,7 @@ app.get('/api/stats', async (context) => {
 app.get('/health', (context) => {
   return context.json({
     status: 'ok',
+    version: APP_VERSION,
     timestamp: new Date().toISOString(),
     projectUrl: 'https://github.com/hossain-khan/trmnl-badges',
   });

--- a/test/endpoints.test.ts
+++ b/test/endpoints.test.ts
@@ -1,6 +1,11 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import app from '../src/index';
-import { mockRecipe, mockRecipeHighEngagement, mockRecipeZeroStats, mockRecipeZeroForks } from './fixtures';
+import {
+  mockRecipe,
+  mockRecipeHighEngagement,
+  mockRecipeZeroStats,
+  mockRecipeZeroForks,
+} from './fixtures';
 
 // Mock the fetchRecipe function
 vi.mock('../src/trmnl-api', () => ({


### PR DESCRIPTION
## Changes

This PR updates the application version to match the latest git tag (1.2.0).

### Updates
- Updated `package.json` version from 1.0.0 to 1.2.0
- Added `APP_VERSION` constant to track version in the codebase
- Enhanced `/health` endpoint to include `version` field in the response
- Applied code formatting with Prettier

### Testing
- All 78 tests passing ✅
- TypeScript type checking passed ✅
- Code formatted with Prettier ✅

### Health Endpoint Response
The `/health` endpoint now returns:
```json
{
  "status": "ok",
  "version": "1.2.0",
  "timestamp": "2026-02-16T...",
  "projectUrl": "https://github.com/hossain-khan/trmnl-badges"
}
```