### PR TITLE
style: Apply TRMNL brand color theme to UI elements

### DIFF
--- a/index.html
+++ b/index.html
@@ -315,7 +315,7 @@
       }
 
       .copy-btn {
-        background: #667eea;
+        background: #f8654b;
         color: white;
         border: none;
         padding: 8px 14px;
@@ -330,9 +330,9 @@
       }
 
       .copy-btn:hover {
-        background: #5568d3;
+        background: #e8523a;
         transform: translateY(-1px);
-        box-shadow: 0 4px 12px rgba(102, 126, 234, 0.3);
+        box-shadow: 0 4px 12px rgba(248, 101, 75, 0.3);
       }
 
       .copy-btn.copied {
@@ -548,7 +548,7 @@
 
       .footer a:hover {
         transform: scale(1.1);
-        color: #667eea;
+        color: #f8654b;
       }
 
       .footer svg {
@@ -762,7 +762,11 @@
 
       <!-- Footer -->
       <footer class="footer">
-        <p class="footer-text">Made with ❤️ for TRMNL Community</p>
+        <p class="footer-text">
+          Made with ❤️ for
+          <a href="https://trmnl.com/developers" target="_blank" rel="noopener noreferrer">TRMNL</a>
+          Community
+        </p>
         |
         <a
           href="https://github.com/hossain-khan/trmnl-badges"


### PR DESCRIPTION
## Changes

Update the UI to use the TRMNL brand color (#F8654B) for better visual consistency:

- Updated copy button background color from blue (#667eea) to TRMNL brand orange-red (#F8654B)
- Updated copy button hover states with brand color (#e8523a) and matching shadow
- Updated footer links hover color to use brand color (#F8654B) instead of blue
- Linked "TRMNL" text in footer to https://trmnl.com/developers

## Visual Impact

The interface now has cohesive brand colors that match the TRMNL logo and design system throughout the application.