### PR TITLE
feat: Add API endpoint to fetch all recipes by user ID

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 import { Hono } from 'hono';
 import { cors } from 'hono/cors';
 import type { Bindings } from './types';
-import { fetchRecipe } from './trmnl-api';
+import { fetchRecipe, fetchUserRecipes } from './trmnl-api';
 import { generateBadge } from './badge-generator';
 import { formatNumber } from './utils';
 import { returnErrorBadge, isRecipeValid, returnSuccessBadge } from './badge-helpers';
@@ -214,6 +214,24 @@ app.get('/api/stats', async (context) => {
 
   context.header('Cache-Control', 'public, max-age=3600');
   return context.json(stats);
+});
+
+// API endpoint for fetching all recipes for a specific user/author
+app.get('/api/recipes', async (context) => {
+  const { user_id } = context.req.query();
+
+  if (!user_id) {
+    return context.json({ error: 'Missing required parameter: user_id' }, 400);
+  }
+
+  const userRecipes = await fetchUserRecipes(user_id);
+
+  if (!userRecipes || !userRecipes.data || userRecipes.data.length === 0) {
+    return context.json({ error: 'No recipes found for this user' }, 404);
+  }
+
+  context.header('Cache-Control', 'public, max-age=3600');
+  return context.json(userRecipes);
 });
 
 ///////////////////////////////////////////////////////////

--- a/src/trmnl-api.ts
+++ b/src/trmnl-api.ts
@@ -37,3 +37,38 @@ export async function fetchRecipe(recipeId: string): Promise<TRMNLRecipe | null>
     return null;
   }
 }
+
+/**
+ * Fetch all recipes for a specific user/author
+ * Returns recipes with their stats (installs, forks)
+ */
+export async function fetchUserRecipes(userId: string): Promise<{ data: TRMNLRecipe[] } | null> {
+  const url = `${TRMNL_API_BASE}/recipes.json?user_id=${encodeURIComponent(userId)}`;
+
+  const headers: Record<string, string> = {
+    Accept: 'application/json',
+    'User-Agent': 'trmnl-badges',
+  };
+
+  try {
+    const response = await fetch(url, { headers });
+
+    const contentType = response.headers.get('content-type');
+    if (!contentType?.includes('application/json')) {
+      return null;
+    }
+
+    if (!response.ok) {
+      if (response.status === 404) {
+        return null;
+      }
+      throw new Error(`TRMNL API error: ${response.status} ${response.statusText}`);
+    }
+
+    const result = (await response.json()) as { data: TRMNLRecipe[] };
+    return result;
+  } catch (error) {
+    console.error('Error fetching user recipes:', error);
+    return null;
+  }
+}


### PR DESCRIPTION
## Overview
This PR adds a new Cloudflare Worker API endpoint to fetch all recipes for a specific user/author, enabling the author badge builder feature.

## Changes
- **`src/trmnl-api.ts`**: Added `fetchUserRecipes()` function to fetch user's recipes from TRMNL API
- **`src/index.ts`**: Added `/api/recipes` GET endpoint that accepts `user_id` query parameter

## New Endpoint
```
GET /api/recipes?user_id={userId}
```

### Request
- **Parameter**: `user_id` (required) - The user ID to fetch recipes for
- **Returns**: Paginated list of recipes with stats

### Response Example
```json
{
  "data": [
    {
      "id": 243525,
      "user_id": 4318,
      "name": "Recipe Name",
      "stats": {
        "installs": 1,
        "forks": 3
      }
    }
  ],
  "total": 6,
  "from": 1,
  "to": 6,
  "per_page": 25,
  "current_page": 1
}
```

### Error Handling
- Returns `400` if `user_id` parameter is missing
- Returns `404` if no recipes found for user
- Includes proper cache headers (`public, max-age=3600`)

## Testing
Test with user_id `4318`:
- Expected: 6 recipes
- Total installs: 16
- Total forks: 204
- Total connections: 220

## Resolves
Closes #20

## Related Issues
- #19 - Create author-badge.html page structure