### PR TITLE
test: add coverage for author badge features

### DIFF
--- a/test/endpoints.test.ts
+++ b/test/endpoints.test.ts
@@ -649,6 +649,48 @@ describe('TRMNL Badges API', () => {
     });
   });
 
+  describe('GET /api/recipes', () => {
+    it('should return 400 when user_id parameter is missing', async () => {
+      const response = await app.request('/api/recipes');
+      expect(response.status).toBe(400);
+
+      const json = await response.json();
+      expect(json).toHaveProperty('error', 'Missing required parameter: user_id');
+    });
+
+    it('should return 404 when no recipes are found for user', async () => {
+      vi.mocked(fetchUserRecipes).mockResolvedValueOnce({ data: [] });
+
+      const response = await app.request('/api/recipes?user_id=9999');
+      expect(response.status).toBe(404);
+
+      const json = await response.json();
+      expect(json).toHaveProperty('error', 'No recipes found for this user');
+    });
+
+    it('should return user recipes with cache header for valid user', async () => {
+      vi.mocked(fetchUserRecipes).mockResolvedValueOnce(mockUserRecipesResponse);
+
+      const response = await app.request('/api/recipes?user_id=29');
+      expect(response.status).toBe(200);
+      expect(response.headers.get('Cache-Control')).toBe('public, max-age=3600');
+
+      const json = (await response.json()) as any;
+      expect(json.data).toHaveLength(3);
+      expect(json.data[0].name).toBe('Kung Fu Panda Quotes');
+    });
+
+    it('should return 404 when fetchUserRecipes returns null', async () => {
+      vi.mocked(fetchUserRecipes).mockResolvedValueOnce(null);
+
+      const response = await app.request('/api/recipes?user_id=29');
+      expect(response.status).toBe(404);
+
+      const json = await response.json();
+      expect(json).toHaveProperty('error', 'No recipes found for this user');
+    });
+  });
+
   describe('GET /badge/counter', () => {
     // Helper to create a mock KV namespace
     const createMockKV = (initialData: Record<string, string> = {}) => {

--- a/test/trmnl-api.test.ts
+++ b/test/trmnl-api.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { fetchRecipe } from '../src/trmnl-api';
-import { mockRecipe } from './fixtures';
+import { fetchRecipe, fetchUserRecipes } from '../src/trmnl-api';
+import { mockRecipe, mockUserRecipesResponse } from './fixtures';
 
 describe('fetchRecipe', () => {
   let mockFetch: ReturnType<typeof vi.fn>;
@@ -124,5 +124,115 @@ describe('fetchRecipe', () => {
     const result = await fetchRecipe('227153');
 
     expect(result).toBeNull();
+  });
+});
+
+describe('fetchUserRecipes', () => {
+  let mockFetch: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    mockFetch = vi.fn();
+    vi.stubGlobal('fetch', mockFetch);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('should return user recipes when API returns valid JSON', async () => {
+    const mockResponse = {
+      ok: true,
+      status: 200,
+      headers: new Map([['content-type', 'application/json; charset=utf-8']]),
+      json: async () => mockUserRecipesResponse,
+    };
+
+    mockFetch.mockResolvedValueOnce(mockResponse as any);
+
+    const result = await fetchUserRecipes('29');
+
+    expect(result).toEqual(mockUserRecipesResponse);
+    expect(mockFetch).toHaveBeenCalledWith('https://trmnl.com/recipes.json?user_id=29', {
+      headers: {
+        Accept: 'application/json',
+        'User-Agent': 'trmnl-badges',
+      },
+    });
+  });
+
+  it('should return null when content-type is not JSON', async () => {
+    const mockResponse = {
+      ok: true,
+      status: 200,
+      headers: new Map([['content-type', 'text/html']]),
+    };
+
+    mockFetch.mockResolvedValueOnce(mockResponse as any);
+
+    const result = await fetchUserRecipes('29');
+
+    expect(result).toBeNull();
+  });
+
+  it('should return null when API returns 404', async () => {
+    const mockResponse = {
+      ok: false,
+      status: 404,
+      statusText: 'Not Found',
+      headers: new Map([['content-type', 'application/json']]),
+    };
+
+    mockFetch.mockResolvedValueOnce(mockResponse as any);
+
+    const result = await fetchUserRecipes('99999');
+
+    expect(result).toBeNull();
+  });
+
+  it('should return null and log error when fetch fails', async () => {
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    mockFetch.mockRejectedValueOnce(new Error('Network error'));
+
+    const result = await fetchUserRecipes('29');
+
+    expect(result).toBeNull();
+    expect(consoleErrorSpy).toHaveBeenCalledWith('Error fetching user recipes:', expect.any(Error));
+    consoleErrorSpy.mockRestore();
+  });
+
+  it('should return null when content-type header is missing', async () => {
+    const mockResponse = {
+      ok: true,
+      status: 200,
+      headers: new Map(),
+      json: async () => mockUserRecipesResponse,
+    };
+
+    mockFetch.mockResolvedValueOnce(mockResponse as any);
+
+    const result = await fetchUserRecipes('29');
+
+    expect(result).toBeNull();
+  });
+
+  it('should encode userId in the URL', async () => {
+    const mockResponse = {
+      ok: true,
+      status: 200,
+      headers: new Map([['content-type', 'application/json']]),
+      json: async () => ({ data: [] }),
+    };
+
+    mockFetch.mockResolvedValueOnce(mockResponse as any);
+
+    await fetchUserRecipes('user 123');
+
+    expect(mockFetch).toHaveBeenCalledWith('https://trmnl.com/recipes.json?user_id=user%20123', {
+      headers: {
+        Accept: 'application/json',
+        'User-Agent': 'trmnl-badges',
+      },
+    });
   });
 });

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -1,5 +1,12 @@
 import { describe, it, expect } from 'vitest';
-import { formatNumber, compactNumberFormatter } from '../src/utils';
+import {
+  formatNumber,
+  compactNumberFormatter,
+  aggregateAuthorStats,
+  isValidUserId,
+} from '../src/utils';
+import type { TRMNLRecipe } from '../src/types';
+import { mockRecipe, mockRecipeZeroStats } from './fixtures';
 
 describe('Utils', () => {
   describe('formatNumber', () => {
@@ -87,6 +94,77 @@ describe('Utils', () => {
         const result = compactNumberFormatter.format(1500000);
         expect(result).toBe('1.5M');
       });
+    });
+  });
+
+  describe('aggregateAuthorStats', () => {
+    it('should return zeros for an empty recipe array', () => {
+      const result = aggregateAuthorStats([]);
+      expect(result).toEqual({ recipes: 0, installs: 0, forks: 0, connections: 0 });
+    });
+
+    it('should aggregate stats from a single recipe', () => {
+      const result = aggregateAuthorStats([mockRecipe]);
+      expect(result).toEqual({ recipes: 1, installs: 7, forks: 5, connections: 12 });
+    });
+
+    it('should aggregate stats from multiple recipes', () => {
+      const recipes: TRMNLRecipe[] = [
+        { ...mockRecipe, stats: { installs: 100, forks: 50 } },
+        { ...mockRecipe, stats: { installs: 75, forks: 30 } },
+        { ...mockRecipe, stats: { installs: 50, forks: 20 } },
+      ];
+      const result = aggregateAuthorStats(recipes);
+      expect(result).toEqual({ recipes: 3, installs: 225, forks: 100, connections: 325 });
+    });
+
+    it('should handle recipes with zero stats', () => {
+      const result = aggregateAuthorStats([mockRecipeZeroStats]);
+      expect(result).toEqual({ recipes: 1, installs: 0, forks: 0, connections: 0 });
+    });
+
+    it('should handle recipes with undefined stats gracefully', () => {
+      const recipeNoStats = { ...mockRecipe, stats: undefined } as any;
+      const result = aggregateAuthorStats([recipeNoStats]);
+      expect(result).toEqual({ recipes: 1, installs: 0, forks: 0, connections: 0 });
+    });
+
+    it('should handle recipes with partial stats (missing forks)', () => {
+      const recipePartial = { ...mockRecipe, stats: { installs: 10 } } as any;
+      const result = aggregateAuthorStats([recipePartial]);
+      expect(result).toEqual({ recipes: 1, installs: 10, forks: 0, connections: 10 });
+    });
+
+    it('should handle recipes with partial stats (missing installs)', () => {
+      const recipePartial = { ...mockRecipe, stats: { forks: 5 } } as any;
+      const result = aggregateAuthorStats([recipePartial]);
+      expect(result).toEqual({ recipes: 1, installs: 0, forks: 5, connections: 5 });
+    });
+  });
+
+  describe('isValidUserId', () => {
+    it('should return true for a valid string userId', () => {
+      expect(isValidUserId('29')).toBe(true);
+    });
+
+    it('should return true for a non-numeric string', () => {
+      expect(isValidUserId('abc')).toBe(true);
+    });
+
+    it('should return false for undefined', () => {
+      expect(isValidUserId(undefined)).toBe(false);
+    });
+
+    it('should return false for an empty string', () => {
+      expect(isValidUserId('')).toBe(false);
+    });
+
+    it('should return false for a whitespace-only string', () => {
+      expect(isValidUserId('   ')).toBe(false);
+    });
+
+    it('should return false for an array of strings', () => {
+      expect(isValidUserId(['29', '30'] as any)).toBe(false);
     });
   });
 });


### PR DESCRIPTION
## Summary

Adds 23 new tests to cover author badge features using `userId`, closing coverage gaps identified during the test audit.

## Coverage Improvement

| Metric | Before | After |
|--------|--------|-------|
| Statements | 89.5% | **94.2%** |
| Branches | 89.6% | **95.8%** |
| Functions | 95.2% | **100%** |
| Total tests | 120 | **143** |

## New Tests

### `utils.test.ts` — `aggregateAuthorStats` (7 tests)
- Empty recipe array
- Single recipe / multiple recipes
- Zero stats, undefined stats, partial stats (missing forks/installs)

### `utils.test.ts` — `isValidUserId` (6 tests)
- Valid string, non-numeric string
- `undefined`, empty string, whitespace-only, array input

### `trmnl-api.test.ts` — `fetchUserRecipes` (6 tests)
- Valid JSON response, non-JSON content-type, 404
- Network error, missing content-type header, URL encoding

### `endpoints.test.ts` — `GET /api/recipes` (4 tests)
- Missing `user_id` param → 400
- No recipes found → 404
- Valid user → 200 with cache header
- Null API response → 404