### PR TITLE
chore: bump version to 1.4.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "trmnl-badges",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "trmnl-badges",
-      "version": "1.3.0",
+      "version": "1.4.0",
       "license": "ISC",
       "dependencies": {
         "badgen": "^3.2.3",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "trmnl-badges",
   "private": true,
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "TRMNL Badges - Cloudflare Workers app for generating TRMNL recipe badges",
   "type": "module",
   "main": "index.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,7 @@ import { formatNumber, aggregateAuthorStats, isValidUserId, incrementBadgeCounte
 import { returnErrorBadge, isRecipeValid, returnSuccessBadge } from './badge-helpers';
 
 // App version - https://github.com/hossain-khan/trmnl-badges/releases
-const APP_VERSION = '1.3.0';
+const APP_VERSION = '1.4.0';
 
 // 🎉 Fun tracking feature: KV store key for total badges served counter
 const BADGES_SERVED_COUNTER_KEY = 'badges_served_total';


### PR DESCRIPTION
## Summary

Bump version to 1.4.0 for next release.

### Changes
- `src/index.ts` — `APP_VERSION` → `1.4.0`
- `package.json` — version → `1.4.0`
- `package-lock.json` — version → `1.4.0`

### What's new in 1.4.0
- Author badge builder with userId support
- Cross-page userId auto-detection (index.html → author-badge.html)
- Inline nav links with "New" pill badge
- Loading spinner on Show Badges button
- Grey color for Hide Badges button
- 23 new tests (120 → 143), coverage 89.5% → 94.2%