### PR TITLE
ui: improve customize toggle UX on author badge builder

### DIFF
--- a/author-badge.html
+++ b/author-badge.html
@@ -136,7 +136,7 @@
       input[type='text']:focus,
       select:focus {
         outline: none;
-        border-color: #667eea;
+        border-color: #a07068;
       }
 
       .checkbox-group {


### PR DESCRIPTION
## Summary

Follow-up UX polish for the "Customize appearance" panel added in PR #33.

## Changes

- **Inline layout** — moved the "Customize appearance" toggle button to sit on the same row as the text input (right-aligned), making use of the horizontal space instead of occupying its own line
- **Warm theme colour** — changed button text/icon from blue (`#667eea`) to a warm greyish-orange (`#a07068`) with a matching hover state (`#8a5c54`), blending with the TRMNL orange/dark-gray palette
- **Matched height** — button uses `align-self: stretch` with identical `padding: 10px 12px`, `border: 2px`, and `font-size: 14px` as the text input, so they sit flush at the same height
- **Matched border** — default border colour set to `#e0e0e0` (same as the text input), warm colour only applied on hover
- **Matched focus ring** — text input focus border changed from blue (`#667eea`) to `#a07068` to stay consistent with the button theme
