### PR TITLE
Release v1.6.0

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -90,7 +90,7 @@ npx tsc --noEmit
 
 ### `src/index.ts` — Route Handlers
 
-The Hono app binds to `Bindings` type (from `src/types.ts`). Current app version: `APP_VERSION = '1.5.0'`.
+The Hono app binds to `Bindings` type (from `src/types.ts`). Current app version: `APP_VERSION = '1.6.0'`.
 
 **Badge endpoints** (return `image/svg+xml`):
 - `GET /badge/installs?recipe=<id>` or `?userId=<id>`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "trmnl-badges",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "trmnl-badges",
-      "version": "1.5.0",
+      "version": "1.6.0",
       "license": "ISC",
       "dependencies": {
         "badgen": "^3.2.3",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "trmnl-badges",
   "private": true,
-  "version": "1.5.0",
+  "version": "1.6.0",
   "description": "TRMNL Badges - Cloudflare Workers app for generating TRMNL recipe badges",
   "type": "module",
   "main": "index.js",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,4 +1,4 @@
 // App version - https://github.com/hossain-khan/trmnl-badges/releases
-export const APP_VERSION = '1.5.0';
+export const APP_VERSION = '1.6.0';
 
 export const APP_USER_AGENT = `trmnl-badges/${APP_VERSION}`;


### PR DESCRIPTION
## Summary
Prepare `v1.6.0` release by bumping project version metadata.

## Changes
- bump `APP_VERSION` to `1.6.0` in `src/constants.ts`
- bump package version to `1.6.0` in `package.json`
- align lockfile version entries in `package-lock.json`
- update Copilot instruction reference to `APP_VERSION = '1.6.0'`

## Files changed
- `.github/copilot-instructions.md`
- `package.json`
- `package-lock.json`
- `src/constants.ts`