### PR TITLE
Add "Link Recipe" checkbox to Individual Recipe Badges in author-badge.html

### DIFF
--- a/author-badge.html
+++ b/author-badge.html
@@ -151,6 +151,7 @@
         width: 18px;
         height: 18px;
         cursor: pointer;
+        accent-color: #f8654b;
       }
 
       .checkbox-label {


### PR DESCRIPTION
## Summary

Adds a **"Link Recipe"** checkbox to the Individual Recipe Badges section in `author-badge.html`, matching the existing "Link to recipe" feature already present in `index.html`.

## Changes

- **New checkbox** in the `recipes-header-row`, placed between the section title and the "📋 Copy All Badges" button — scoped visually to the section it controls.
- **Updated `generateRecipeBadgeMarkdown()`** — when checked, wraps the badge image in a clickable Markdown link pointing to `https://trmnl.com/recipes/<id>`:
  - Unchecked: `![Installs](https://trmnl-badges.gohk.xyz/badge/installs?recipe=123)`
  - Checked: `[![Installs](https://trmnl-badges.gohk.xyz/badge/installs?recipe=123)](https://trmnl.com/recipes/123)`
- All copy buttons (individual "Copy Markdown", "Copy All 3 Badges", and global "Copy All Badges") automatically respect the checkbox state at click-time — no additional event wiring needed.
- **Applied TRMNL brand `accent-color: #f8654b`** to `input[type='checkbox']` to match the same orange color treatment used in `index.html`.