### PR TITLE
Add dynamic tooltip to Link Recipe checkbox

### DIFF
--- a/author-badge.html
+++ b/author-badge.html
@@ -1505,7 +1505,7 @@
           <div class="recipes-header">
             Individual Recipe Badges (<span id="recipeCount">0</span> recipes)
           </div>
-          <div class="checkbox-group">
+          <div class="checkbox-group" title="Badge markdown will NOT include a link to the recipe">
             <input type="checkbox" id="linkToRecipe" />
             <label for="linkToRecipe" class="checkbox-label">Link Recipe</label>
           </div>
@@ -2079,6 +2079,16 @@
           generateBtn.textContent = 'Generate Author Badges';
         }
       }
+
+      // Update Link Recipe checkbox tooltip based on state
+      const linkToRecipeCheckbox = document.getElementById('linkToRecipe');
+      const linkToRecipeGroup = linkToRecipeCheckbox.closest('.checkbox-group');
+      function updateLinkRecipeTooltip() {
+        linkToRecipeGroup.title = linkToRecipeCheckbox.checked
+          ? 'Badge markdown will include a clickable link to the recipe page'
+          : 'Badge markdown will NOT include a link to the recipe';
+      }
+      linkToRecipeCheckbox.addEventListener('change', updateLinkRecipeTooltip);
 
       // Event listeners
       generateBtn.addEventListener('click', generateAuthorBadges);


### PR DESCRIPTION
## Summary

Adds a dynamic tooltip to the **Link Recipe** checkbox in the Individual Recipe Badges section of `author-badge.html`.

### Behavior

The tooltip text updates based on the checkbox state:
- **Unchecked (OFF):** `"Badge markdown will NOT include a link to the recipe"`
- **Checked (ON):** `"Badge markdown will include a clickable link to the recipe page"`

### Changes

- Set `title` attribute on the `.checkbox-group` container with the default (unchecked) tooltip text
- Added a `change` event listener on the checkbox that calls `updateLinkRecipeTooltip()` to swap the tooltip text on toggle