### PR TITLE
Add animated CSS tooltip to Link to recipe checkbox in index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -232,6 +232,55 @@
         gap: 8px;
       }
 
+      /* Custom animated tooltip */
+      .checkbox-group[data-tooltip] {
+        position: relative;
+      }
+
+      .checkbox-group[data-tooltip]::after,
+      .checkbox-group[data-tooltip]::before {
+        pointer-events: none;
+        opacity: 0;
+        transition:
+          opacity 0.18s ease,
+          transform 0.18s ease;
+      }
+
+      .checkbox-group[data-tooltip]::after {
+        content: attr(data-tooltip);
+        position: absolute;
+        bottom: calc(100% + 9px);
+        left: 50%;
+        transform: translateX(-50%) translateY(6px);
+        background: #3d3d3e;
+        color: #fff;
+        font-size: 12px;
+        font-weight: 400;
+        line-height: 1.4;
+        padding: 6px 10px;
+        border-radius: 6px;
+        white-space: nowrap;
+        z-index: 100;
+        box-shadow: 0 4px 12px rgba(0, 0, 0, 0.2);
+      }
+
+      .checkbox-group[data-tooltip]::before {
+        content: '';
+        position: absolute;
+        bottom: calc(100% + 1px);
+        left: 50%;
+        transform: translateX(-50%) translateY(6px);
+        border: 5px solid transparent;
+        border-top-color: #3d3d3e;
+        z-index: 100;
+      }
+
+      .checkbox-group[data-tooltip]:hover::after,
+      .checkbox-group[data-tooltip]:hover::before {
+        opacity: 1;
+        transform: translateX(-50%) translateY(0);
+      }
+
       input[type='checkbox'] {
         width: 18px;
         height: 18px;
@@ -1381,7 +1430,10 @@
                   </g></svg
                 >Copy Markdown code</span
               >
-              <div class="checkbox-group">
+              <div
+                class="checkbox-group"
+                data-tooltip="Badge markdown will NOT include a link to the recipe"
+              >
                 <input type="checkbox" id="linkToRecipe" />
                 <label for="linkToRecipe" class="checkbox-label">Link to recipe</label>
               </div>
@@ -1785,7 +1837,12 @@
       badgeTypeRadios.forEach((radio) => radio.addEventListener('change', update));
       customLabel.addEventListener('input', debouncedUpdate); // Debounced to prevent excessive requests
       prettyFormat.addEventListener('change', update);
-      linkToRecipe.addEventListener('change', update);
+      linkToRecipe.addEventListener('change', () => {
+        linkToRecipe.closest('.checkbox-group').dataset.tooltip = linkToRecipe.checked
+          ? 'Badge markdown will include a clickable link to the recipe page'
+          : 'Badge markdown will NOT include a link to the recipe';
+        update();
+      });
       glyphRadios.forEach((radio) => radio.addEventListener('change', update));
       badgeColor.addEventListener('input', debouncedUpdate);
       labelColorInput.addEventListener('input', debouncedUpdate);


### PR DESCRIPTION
## Summary

Ports the animated CSS tooltip from `author-badge.html` (PR #61) to the **Link to recipe** checkbox in `index.html`.

### Tooltip behavior
- **Unchecked (OFF):** `"Badge markdown will NOT include a link to the recipe"`
- **Checked (ON):** `"Badge markdown will include a clickable link to the recipe page"`

### Details
- Custom CSS tooltip using `::before`/`::after` pseudo-elements on `[data-tooltip]`
- **TRMNL brand styling** — dark `#3d3d3e` background, white text, rounded corners, drop shadow
- **Arrow indicator** — downward-pointing triangle anchored to the element
- **Smooth animation** — fade-in + 6px upward slide on hover (180ms ease)
- JS updates `data-tooltip` attribute on checkbox `change`; CSS `attr()` reads it automatically
- The `linkToRecipe.addEventListener('change', update)` call is replaced with an inline handler that updates the tooltip text then calls `update()`