### PR TITLE
feat: link recipe-id in subtitle to index.html with prefill and positive-integer validation

### DIFF
--- a/author-badge.html
+++ b/author-badge.html
@@ -752,6 +752,11 @@
         text-overflow: ellipsis;
       }
 
+      .recipe-item-stats .recipe-id-link {
+        color: inherit;
+        text-decoration: none;
+      }
+
       .recipe-item-action {
         flex-shrink: 0;
       }
@@ -1987,7 +1992,16 @@
           const statsDiv = document.createElement('div');
           statsDiv.className = 'recipe-item-stats';
           const isPretty = prettyFormat.checked;
-          statsDiv.textContent = `${formatNumber(recipe.stats.installs, isPretty)} installs • ${formatNumber(recipe.stats.forks, isPretty)} forks • ${formatNumber(recipe.stats.installs + recipe.stats.forks, isPretty)} connections • recipe-id ${recipe.id}`;
+          statsDiv.appendChild(
+            document.createTextNode(
+              `${formatNumber(recipe.stats.installs, isPretty)} installs • ${formatNumber(recipe.stats.forks, isPretty)} forks • ${formatNumber(recipe.stats.installs + recipe.stats.forks, isPretty)} connections • `
+            )
+          );
+          const recipeIdLink = document.createElement('a');
+          recipeIdLink.textContent = `recipe-id ${recipe.id}`;
+          recipeIdLink.href = `index.html?recipeId=${recipe.id}${getCustomParams()}`;
+          recipeIdLink.className = 'recipe-id-link';
+          statsDiv.appendChild(recipeIdLink);
 
           infoDiv.appendChild(nameDiv);
           infoDiv.appendChild(statsDiv);

--- a/index.html
+++ b/index.html
@@ -1892,6 +1892,12 @@
         if (normalizedLabelColor) {
           labelColorInput.value = normalizedLabelColor;
         }
+        const recipeIdParam = params.get('recipeId');
+        const recipeIdNum = Number(recipeIdParam);
+        if (recipeIdParam && Number.isInteger(recipeIdNum) && recipeIdNum > 0) {
+          recipeInput.value = String(recipeIdNum);
+          recipeInputTouched = true;
+        }
       }
 
       async function update() {


### PR DESCRIPTION
## Summary

Improves the recipe subtitle UX in the individual recipes section of the author badge builder by making `recipe-id XYZ` a navigable link into the single-recipe badge builder, with auto-prefill on arrival.

### Changes

#### `author-badge.html`
- The `"recipe-id XYZ"` portion of the subtitle is now an `<a>` element linking to `index.html?recipeId=XYZ`
- Any current customization params (glyph, color, labelColor) are forwarded as query params so the badge renders with the same appearance
- Navigates in the **same tab**
- Link is styled with `color: inherit; text-decoration: none` so it is visually identical to the surrounding gray stats text — no distraction, full text reads as one cohesive line:
  > `1159 installs • 36 forks • 1195 connections • recipe-id 9917`

#### `index.html`
- Extended `applyUrlParams()` to read `recipeId` from the URL query string
- **Positive-integer validation**: rejects non-numeric values, floats, zero, negatives, and empty strings (`Number.isInteger(n) && n > 0`)
- If valid, prefills `recipeInput` and sets `recipeInputTouched = true`, so the existing `update()` call auto-loads the badge preview and shows "Recipe ID valid" feedback immediately

### How it works end-to-end
1. User generates badges for their author page
2. In the individual recipes list, they click `recipe-id 9917` in the subtitle
3. `index.html?recipeId=9917` loads — input is prefilled, badge preview renders automatically
4. User customizes and copies the badge markdown for that specific recipe