### PR TITLE
fix: correct recipe lookup validation regression in author-badge

### DIFF
--- a/author-badge.html
+++ b/author-badge.html
@@ -579,11 +579,13 @@
           // First fetch the recipe to get its user_id
           const recipeResponse = await fetch(`${BASE_URL}/api/stats?recipe=${recipeId}`);
           if (!recipeResponse.ok) {
+            console.debug(`Recipe lookup failed for recipe ID ${recipeId}: ${recipeResponse.status}`);
             return null;
           }
 
           const recipeData = await recipeResponse.json();
-          if (!recipeData || !recipeData.stats) {
+          if (!recipeData || !recipeData.user_id) {
+            console.debug(`Recipe data missing or invalid for recipe ID ${recipeId}:`, recipeData);
             return null;
           }
 


### PR DESCRIPTION
## Problem
After fixing issue #71, a regression was introduced in `author-badge.html`. When pasting a recipe URL like `https://trmnl.com/recipes/240176`, the page shows "No recipes found" error.

## Root Cause
The `fetchUserRecipesFromRecipe()` function was checking for `recipeData.stats` instead of `recipeData.user_id` in the validation:

```javascript
// ❌ WRONG - API returns user_id
if (!recipeData || !recipeData.stats) {
  return null;
}
```

The backend `/api/stats` endpoint returns `user_id` in the response, but this validation was checking for `stats`, causing valid recipe responses to be rejected.

## Solution
Changed validation to check for the correct field:

```javascript
// ✅ CORRECT - Check for user_id which we need
if (!recipeData || !recipeData.user_id) {
  return null;
}
```

Also added debug logging to help diagnose similar issues in the future.

## Testing
- ✅ Paste recipe URL `https://trmnl.com/recipes/240176` → should now work
- ✅ Direct user ID entry should still work
- ✅ `?userId=` URL parameter should still work