### PR TITLE
Fix: Wrap generateAuthorBadges in arrow function to prevent PointerEvent leak

### DIFF
--- a/author-badge.html
+++ b/author-badge.html
@@ -1125,6 +1125,10 @@
       linkToRecipeCheckbox.addEventListener('change', updateLinkRecipeTooltip);
 
       // Event listeners
+      // NOTE: Use arrow function to prevent click event from being passed as isUserId parameter.
+      // Direct reference (generateBtn.addEventListener('click', generateAuthorBadges)) would pass
+      // the PointerEvent as the first argument, binding it to isUserId and making it truthy,
+      // causing the recipe lookup logic to be skipped. See issue/PR history for details.
       generateBtn.addEventListener('click', () => generateAuthorBadges());
       authorInput.addEventListener('keypress', (e) => {
         if (e.key === 'Enter') {

--- a/author-badge.html
+++ b/author-badge.html
@@ -1125,7 +1125,7 @@
       linkToRecipeCheckbox.addEventListener('change', updateLinkRecipeTooltip);
 
       // Event listeners
-      generateBtn.addEventListener('click', generateAuthorBadges);
+      generateBtn.addEventListener('click', () => generateAuthorBadges());
       authorInput.addEventListener('keypress', (e) => {
         if (e.key === 'Enter') {
           generateAuthorBadges();


### PR DESCRIPTION
## Fix: Prevent PointerEvent from being passed as isUserId parameter

### Root Cause
The click event listener was directly passing the `PointerEvent` object as the first parameter to `generateAuthorBadges`:

```javascript
generateBtn.addEventListener('click', generateAuthorBadges);
// When clicked, this passes: generateAuthorBadges(PointerEvent)
```

This caused the PointerEvent to be bound to the `isUserId` parameter. Since objects are truthy:
- `if (!isUserId)` evaluated to `false`
- Recipe lookup was skipped
- Code fell through to treating recipe ID as user ID directly
- Result: 404 error on `/api/recipes?user_id=240176`

### Solution
Wrap in an arrow function to prevent the event from being passed:

```javascript
generateBtn.addEventListener('click', () => generateAuthorBadges());
// Now properly calls: generateAuthorBadges() with no arguments
```

### Additional Changes
- Added explanatory comment in code to prevent future regressions
- Comment documents why the arrow function pattern is necessary and references issue/PR history

### Testing
- Paste recipe URL: `https://trmnl.com/recipes/240176`
- Click "Generate Author Badges"
- Should now properly fetch recipe #240176, get user ID 29, then fetch all recipes
- No more 404 errors

### Related
Follows from debug logging in PR #76 which revealed `isUserId=[object PointerEvent]`