### PR TITLE
feat: use white glyph for /badge/counter endpoint

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -531,6 +531,7 @@ app.get('/badge/counter', async (context) => {
   const badge = generateBadge({
     label: 'Badges Served',
     message: formatNumber(validCount, true),
+    glyph: 'white',
   });
 
   return returnSuccessBadge(context, badge);


### PR DESCRIPTION
## Summary

Updates the `/badge/counter` endpoint to use the `white` glyph variant instead of the default (brand) glyph.

## Changes

- `src/index.ts`: Added `glyph: 'white'` to the `generateBadge` call in the `/badge/counter` handler.