### PR TITLE
fix: intercept upstream redirects for unknown recipe IDs to return 404

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -103,7 +103,7 @@ Returned when the specified recipe ID does not exist on `trmnl.com`.
 }
 ```
 
-> **Deployment Discrepancy Note:** In the current live deployment at `https://trmnl-badges.gohk.xyz`, requests for non-existent recipe IDs return `HTTP 500 Internal Server Error` (`Internal Server Error` plain text) due to upstream redirect handling (upstream `trmnl.com` redirects non-existent recipe JSON requests to `/recipes` with an HTML page). The source implementation handles non-JSON redirect responses to correctly return `HTTP 404`. Redeploying the Worker from the latest source code resolves this discrepancy.
+> **Upstream Redirect Handling:** When a recipe ID does not exist on `trmnl.com`, the upstream API returns an `HTTP 302` redirect to `/recipes`. The `trmnl-badges` service explicitly intercepts 3xx redirects for recipe lookups and converts them into a clean `HTTP 404` (`Recipe not found`) response.
 
 ##### Server or Upstream Error (`HTTP 500 Internal Server Error`)
 

--- a/src/trmnl-api.ts
+++ b/src/trmnl-api.ts
@@ -99,12 +99,17 @@ function getInFlightOrCreate<T>(
   return promise;
 }
 
-async function fetchTrmnlJson(url: string, headers: Record<string, string>): Promise<Response> {
+async function fetchTrmnlJson(
+  url: string,
+  headers: Record<string, string>,
+  options?: RequestInit
+): Promise<Response> {
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), TRMNL_API_TIMEOUT_MS);
 
   try {
     return await fetch(url, {
+      ...options,
       headers,
       signal: controller.signal,
       // Ask Cloudflare to keep a short upstream cache to reduce burst traffic.
@@ -131,12 +136,21 @@ export async function fetchRecipe(recipeId: string): Promise<TRMNLRecipe | null>
 
   return getInFlightOrCreate(inFlightRecipeRequests, url, 'recipe', async () => {
     try {
-      const response = await fetchTrmnlJson(url, headers);
+      // Use redirect: 'manual' to catch upstream 302 redirects for non-existent recipes
+      const response = await fetchTrmnlJson(url, headers, { redirect: 'manual' });
 
-      // Check if response is JSON (a 302 redirect to recipes page returns HTML)
+      // Handle upstream redirects (TRMNL API redirects non-existent recipes to /recipes)
+      if (response.status >= 300 && response.status < 400) {
+        return null;
+      }
+
+      if (response.redirected) {
+        return null;
+      }
+
+      // Check if response is JSON (a redirect or HTML error page is non-JSON)
       const contentType = response.headers.get('content-type');
       if (!contentType?.includes('application/json')) {
-        // Recipe not found (API redirects to recipe list page with HTML, or other non-JSON response)
         return null;
       }
 
@@ -148,6 +162,18 @@ export async function fetchRecipe(recipeId: string): Promise<TRMNLRecipe | null>
       }
 
       const result = (await response.json()) as { data: TRMNLRecipe };
+
+      // Ensure data is a valid single recipe object with stats, not an Array or missing stats
+      if (
+        !result ||
+        !result.data ||
+        Array.isArray(result.data) ||
+        typeof result.data !== 'object' ||
+        !('stats' in result.data)
+      ) {
+        return null;
+      }
+
       return result.data;
     } catch (error) {
       recordUpstreamFailure(error, url);

--- a/test/endpoints.test.ts
+++ b/test/endpoints.test.ts
@@ -881,6 +881,16 @@ describe('TRMNL Badges API', () => {
       expect(json).toHaveProperty('error', 'Recipe not found');
     });
 
+    it('should return 404 when recipe=0 is requested', async () => {
+      vi.mocked(fetchRecipe).mockResolvedValueOnce(null);
+
+      const response = await app.request('/api/stats?recipe=0');
+      expect(response.status).toBe(404);
+
+      const json = await response.json();
+      expect(json).toHaveProperty('error', 'Recipe not found');
+    });
+
     it('should return JSON stats for a valid recipe', async () => {
       vi.mocked(fetchRecipe).mockResolvedValueOnce(mockRecipe);
 

--- a/test/trmnl-api.test.ts
+++ b/test/trmnl-api.test.ts
@@ -48,16 +48,38 @@ describe('fetchRecipe', () => {
     );
   });
 
-  it('should return null when recipe does not exist (302 redirect with HTML)', async () => {
+  it('should return null when recipe does not exist (302 redirect with Location header)', async () => {
     const mockResponse = {
       ok: false,
       status: 302,
-      headers: new Map([['content-type', 'text/html; charset=utf-8']]),
+      headers: new Map([
+        ['location', 'https://trmnl.com/recipes'],
+        ['content-type', 'text/html; charset=utf-8'],
+      ]),
     };
 
     mockFetch.mockResolvedValueOnce(mockResponse as any);
 
     const result = await fetchRecipe('22715322');
+
+    expect(result).toBeNull();
+    expect(mockFetch).toHaveBeenCalledWith(
+      'https://trmnl.com/recipes/22715322.json',
+      expect.objectContaining({ redirect: 'manual' })
+    );
+  });
+
+  it('should return null when API returns an array in data field (redirected list JSON response)', async () => {
+    const mockResponse = {
+      ok: true,
+      status: 200,
+      headers: new Map([['content-type', 'application/json; charset=utf-8']]),
+      json: async () => ({ data: [{ id: 1, name: 'Recipe 1' }] }),
+    };
+
+    mockFetch.mockResolvedValueOnce(mockResponse as any);
+
+    const result = await fetchRecipe('0');
 
     expect(result).toBeNull();
   });


### PR DESCRIPTION
## Summary

Fixes the production issue where querying non-existent recipe IDs on `GET /api/stats?recipe=0` returned `HTTP 500 Internal Server Error` instead of `HTTP 404 Not Found`.

### Root Cause
When querying a non-existent recipe ID (e.g., `0`), upstream `trmnl.com/recipes/0.json` returns an `HTTP 302` redirect to `https://trmnl.com/recipes`. Default `fetch()` followed this redirect with `Accept: application/json`, which returned `HTTP 200 OK` with an array of all recipes (`{ data: [...] }`). Casting this as a single recipe object caused `recipeData.stats` to be `undefined`, throwing an uncaught `TypeError` in `/api/stats` resulting in an HTTP 500.

### Changes
- Updated `fetchRecipe()` in `src/trmnl-api.ts` to use `redirect: 'manual'` to catch 3xx redirects for missing recipes and return `null`.
- Added object shape validation for `result.data` to ensure it is a valid single recipe object (not an array).
- Updated unit tests in `test/trmnl-api.test.ts` and integration tests in `test/endpoints.test.ts`.
- Updated documentation in `docs/api.md`.

### Verification
- All 197 Vitest unit & integration tests passing (`npm test -- --run`).
- Type check passing (`npx tsc --noEmit`).
- HTML validation passing (`npm run validate:html`).
- Prettier check passing (`npx prettier --check .`).