### PR TITLE
Release v1.8.0

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -92,7 +92,7 @@ npx tsc --noEmit
 
 ### `src/index.ts` — Route Handlers
 
-The Hono app binds to `Bindings` type (from `src/types.ts`). Current app version: `APP_VERSION = '1.7.0'`.
+The Hono app binds to `Bindings` type (from `src/types.ts`). Current app version: `APP_VERSION = '1.8.0'`.
 
 **Badge endpoints** (return `image/svg+xml`):
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "trmnl-badges",
   "private": true,
-  "version": "1.7.0",
+  "version": "1.8.0",
   "description": "TRMNL Badges - Cloudflare Workers app for generating TRMNL recipe badges",
   "type": "module",
   "main": "index.js",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,4 +1,4 @@
 // App version - https://github.com/hossain-khan/trmnl-badges/releases
-export const APP_VERSION = '1.7.0';
+export const APP_VERSION = '1.8.0';
 
 export const APP_USER_AGENT = `trmnl-badges/${APP_VERSION}`;


### PR DESCRIPTION
## Release v1.8.0

Release preparation for version **1.8.0**.

### Release Notes

#### 🐛 Bug Fixes
- **Unknown Recipe Redirect Handling**: Intercepted upstream `trmnl.com` 302 redirects when querying non-existent recipe IDs so the API correctly returns `404 Not Found` instead of failing downstream parsing (#90).

#### 📚 API Documentation & DX
- **Public JSON Proxy API Documentation**: Created `docs/api.md` as requested by Shields.io reviewers. Updated `README.md` and `llms.txt` with links and accurate response schemas (#88).
- **Inline Route Specs & JSDoc**: Added inline JSDoc comments and direct API documentation links above all route handlers in `src/index.ts` (#89).

#### 🌐 Metadata & Discovery
- **`llms.txt` Discovery Link**: Added `<link rel="alternate" type="text/plain" href="/llms.txt">` metadata tags to `index.html` and `author-badge.html` (#87).

#### 📦 Version Updates
- Updated version to `1.8.0` in `package.json`, `src/constants.ts`, and `.github/copilot-instructions.md`.

### Verification
- `npx tsc --noEmit` passed cleanly.
- `npm run validate:html` passed cleanly.
- `npm test -- --run` passed (197 tests passing).

### Post-Merge Deployment
After merging this PR:
1. Create GitHub release for tag `1.8.0`: `gh release create 1.8.0 --generate-notes`
2. Deploy to Cloudflare Workers: `npm run deploy`